### PR TITLE
add ethereum.org explainers

### DIFF
--- a/english/explainers/README.md
+++ b/english/explainers/README.md
@@ -1,0 +1,11 @@
+# Explainers
+
+Articles providing accessible explanations for various aspects of The Merge.
+
+## ethereum.org
+1) [What is the Merge?](https://ethereum.org/en/upgrades/merge)
+2) [Ethereum's energy consumption](https://ethereum.org/en/energy-consumption)
+3) [What is Proof of Stake?](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos)
+4) [Ethereum's PoS mechanism](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/gasper)
+5) [What is the Beacon Chain?](https://ethereum.org/en/upgrades/beacon-chain)
+6) [How the merge affects ETH supply](https://ethereum.org/en/upgrades/merge/issuance/#how-the-merge-impacts-ETH-supply)


### PR DESCRIPTION
Adding some low-hanging fruit from ethereum.org - we have been developing these specific pages in anticipation of the merge.

Suggest an "explainers" dir to hold these kind of resources. 

Thanks!

